### PR TITLE
Rename the existing gem to `asciidoctor-rfc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ TODO: Delete this and the text above, and describe your gem
 Add this line to your application's Gemfile:
 
 ```ruby
-gem "ascii_doctor_rfc"
+gem "asciidoctor-rfc"
 ```
 
 And then execute:
@@ -22,7 +22,7 @@ $ bundle
 Or install it yourself as:
 
 ```sh
-$ gem install ascii_doctor_rfc
+$ gem install asciidoctor-rfc
 ```
 
 ## Usage

--- a/asciidoctor-rfc.gemspec
+++ b/asciidoctor-rfc.gemspec
@@ -1,11 +1,11 @@
 # coding: utf-8
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "ascii_doctor_rfc/version"
+require "asciidoctor/rfc/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "ascii_doctor_rfc"
-  spec.version       = AsciiDoctorRFC::VERSION
+  spec.name          = "asciidoctor-rfc"
+  spec.version       = Asciidoctor::Rfc::VERSION
   spec.authors       = ["Ribose Inc."]
   spec.email         = ["open.source@ribose.com"]
   spec.summary       = %q{todo: AsciiDoctorRFC description.}

--- a/lib/ascii_doctor_rfc.rb
+++ b/lib/ascii_doctor_rfc.rb
@@ -1,3 +1,0 @@
-module AsciiDoctorRFC
-  # todo
-end

--- a/lib/ascii_doctor_rfc/version.rb
+++ b/lib/ascii_doctor_rfc/version.rb
@@ -1,3 +1,0 @@
-module AsciiDoctorRFC
-  VERSION = "0.1.0".freeze
-end

--- a/lib/asciidoctor/rfc.rb
+++ b/lib/asciidoctor/rfc.rb
@@ -1,0 +1,7 @@
+require "asciidoctor/rfc/version"
+
+module Asciidoctor
+  module Rfc
+    # Your code goes here...
+  end
+end

--- a/lib/asciidoctor/rfc/version.rb
+++ b/lib/asciidoctor/rfc/version.rb
@@ -1,0 +1,5 @@
+module Asciidoctor
+  module Rfc
+    VERSION = "0.1.0".freeze
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require "bundler/setup"
-require "ascii_doctor_rfc"
+require "asciidoctor/rfc"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
This commit rename the gem to `asciidoctor-rfc`, and it also updates the directory structure and others files as necessary, For simplicity it is using the `Asciidoctor::Rfc` namespace for the gem files.