### PR TITLE
Fix V2 code to allow PIs and minimize diffs with davies-template-bare-06

### DIFF
--- a/asciidoctor-rfc.gemspec
+++ b/asciidoctor-rfc.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "asciidoctor", "~> 1.5.6"
   spec.add_dependency "htmlentities", "~> 4.3.4"
   spec.add_dependency "nokogiri", "~> 1.8.1"
+  spec.add_dependency "thread_safe"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 12.0"

--- a/lib/asciidoctor/rfc/common/base.rb
+++ b/lib/asciidoctor/rfc/common/base.rb
@@ -195,7 +195,7 @@ HERE
 
       def attr_code(attributes)
         attributes = attributes.reject { |_, val| val.nil? }.map
-        return attributes.map do |k, v| 
+        return attributes.map do |k, v|
           [k, ((v.is_a? String) ? HTMLEntities.new.decode(v) : v)]
         end.to_h
       end

--- a/lib/asciidoctor/rfc/v2/base.rb
+++ b/lib/asciidoctor/rfc/v2/base.rb
@@ -268,45 +268,42 @@ module Asciidoctor
       end
 
       def set_pis(node, doc)
-
         # Below are generally applicable Processing Instructions (PIs)
         # that most I-Ds might want to use. (Here they are set differently than
         # their defaults in xml2rfc v1.32)
-
         rfc_pis = {
           # give errors regarding ID-nits and DTD validation
-          strict: "yes",
+          strict: 'yes',
 
           # TOC control
           # generate a ToC
-          toc: node.attr("toc-include") == "false" ? "no" : "yes",
+          toc: node.attr('toc-include') == 'false' ? 'no' : 'yes',
 
           # the number of levels of subsections in ToC. default: 3
-          tocdepth: node.attr("toc-depth") || "4",
+          tocdepth: node.attr('toc-depth') || '4',
 
           # References control
 
           # use symbolic references tags, i.e, [RFC2119] instead of [1]
-          symrefs: "yes",
+          symrefs: 'yes',
 
           # sort the reference entries alphabetically
-          sortrefs: "yes",
+          sortrefs: 'yes',
 
           # Vertical whitespace control
           # (using these PIs as follows is recommended by the RFC Editor)
 
           # do not start each main section on a new page
-          compact: "yes",
+          compact: 'yes',
 
           # keep one blank line between list items
-          subcompact: "no"
+          subcompact: 'no'
         }
 
         rfc_pis.each_pair do |k, v|
-          pi = Nokogiri::XML::ProcessingInstruction.new(
-            doc,
-            "rfc",
-            "#{k.to_s}=\"#{v}\""
+          pi = Nokogiri::XML::ProcessingInstruction.new(doc,
+            'rfc',
+            "#{k}=\"#{v}\"",
           )
           doc.root.add_previous_sibling(pi)
         end

--- a/lib/asciidoctor/rfc/v2/front.rb
+++ b/lib/asciidoctor/rfc/v2/front.rb
@@ -35,27 +35,34 @@ module Asciidoctor
         phone = node.attr("phone#{suffix}")
         street = node.attr("street#{suffix}")
         uri = node.attr("uri#{suffix}")
-        if [email, facsimile, phone, street, uri].any?
-          xml.address do |xml_address|
-            if [street].any?
-              xml_address.postal do |xml_postal|
-                city = node.attr("city#{suffix}")
-                code = node.attr("code#{suffix}")
-                country = node.attr("country#{suffix}")
-                region = node.attr("region#{suffix}")
-                street&.split("\\ ")&.each { |st| xml_postal.street { |s| s << st } }
-                xml_postal.city { |c| c << city } unless city.nil?
-                xml_postal.region { |r| r << region } unless region.nil?
-                xml_postal.code { |c| c << code } unless code.nil?
-                xml_postal.country { |c| c << country } unless country.nil?
-              end
-            end
-            xml_address.phone { |p| p << phone } unless phone.nil?
-            xml_address.facsimile { |f| f << facsimile } unless facsimile.nil?
-            xml_address.email { |e| e << email } unless email.nil?
-            xml_address.uri { |u| u << uri } unless uri.nil?
+        return unless [email, facsimile, phone, street, uri].any?
+
+        xml.address do |xml_address|
+
+          xml_address.postal do |xml_postal|
+            city = node.attr("city#{suffix}")
+            code = node.attr("code#{suffix}")
+            country = node.attr("country#{suffix}")
+            region = node.attr("region#{suffix}")
+
+            # https://tools.ietf.org/html/rfc7749#section-2.27
+            # Note that at least one <street> element needs to be present; however,
+            # formatters will handle empty values just fine.
+            street = street ? street.split("\\ ") : [""]
+            street.each { |st| xml_postal.street { |s| s << st } }
+
+            xml_postal.city { |c| c << city } unless city.nil?
+            xml_postal.region { |r| r << region } unless region.nil?
+            xml_postal.code { |c| c << code } unless code.nil?
+            xml_postal.country { |c| c << country } unless country.nil?
           end
+
+          xml_address.phone { |p| p << phone } unless phone.nil?
+          xml_address.facsimile { |f| f << facsimile } unless facsimile.nil?
+          xml_address.email { |e| e << email } unless email.nil?
+          xml_address.uri { |u| u << uri } unless uri.nil?
         end
+
       end
     end
   end

--- a/lib/asciidoctor/rfc/v2/front.rb
+++ b/lib/asciidoctor/rfc/v2/front.rb
@@ -35,22 +35,23 @@ module Asciidoctor
         phone = node.attr("phone#{suffix}")
         street = node.attr("street#{suffix}")
         uri = node.attr("uri#{suffix}")
+
+        # If there is no provided elements for address, don't show it
         return unless [email, facsimile, phone, street, uri].any?
 
-        xml.address do |xml_address|
+        # https://tools.ietf.org/html/rfc7749#section-2.27
+        # Note that at least one <street> element needs to be present;
+        # however, formatters will handle empty values just fine.
+        street = street ? street.split("\\ ") : [""]
 
+        xml.address do |xml_address|
           xml_address.postal do |xml_postal|
             city = node.attr("city#{suffix}")
             code = node.attr("code#{suffix}")
             country = node.attr("country#{suffix}")
             region = node.attr("region#{suffix}")
 
-            # https://tools.ietf.org/html/rfc7749#section-2.27
-            # Note that at least one <street> element needs to be present; however,
-            # formatters will handle empty values just fine.
-            street = street ? street.split("\\ ") : [""]
             street.each { |st| xml_postal.street { |s| s << st } }
-
             xml_postal.city { |c| c << city } unless city.nil?
             xml_postal.region { |r| r << region } unless region.nil?
             xml_postal.code { |c| c << code } unless code.nil?

--- a/spec/examples/davies-template-bare-06.adoc
+++ b/spec/examples/davies-template-bare-06.adoc
@@ -90,7 +90,7 @@ Tables use ttcol to define column headers and widths. Every cell then has a "c" 
 
 [[table_example]]
 .A Very Simple Table
-[cols="2*^"]
+[cols="2*^", frame="sides", grid="cols"]
 |===
 |ttcol #1 |ttcol #2
 

--- a/spec/examples/davies-template-bare-06.adoc
+++ b/spec/examples/davies-template-bare-06.adoc
@@ -14,7 +14,7 @@ Elwyn Davies <elwynd@dial.pipex.com>
 :country: UK
 :phone: +44 7889 488 335
 :email: elwynd@dial.pipex.com
-:revdate: 2010
+:revdate: 2010-04-01
 :area: General
 :workgroup: Internet Engineering Task Force
 :keyword: template
@@ -24,15 +24,18 @@ Insert an abstract: MANDATORY. This template is for creating an
 Internet Draft.
 
 == Introduction
-The original specification of xml2rfc format is in <<RFC2629,RFC&#x00A0;2629>>.
+
+The original specification of xml2rfc format is in <<RFC2629,RFC 2629>>.
 
 === Requirements Language
+
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
 document are to be interpreted as described in <<RFC2119,RFC 2119>>.
 
 [[simple_list]]
 == Simple List
+
 List styles: 'empty', 'symbols', 'letters', 'numbers', 'hanging',
 'format'.
 
@@ -40,9 +43,11 @@ List styles: 'empty', 'symbols', 'letters', 'numbers', 'hanging',
 
 * Second bullet
 
-You can write text here as well. [Note: Asciidoc will force new paragraph]
+You can write text here as well.
+//[Note: Asciidoc will force new paragraph]
 
 == Figures
+
 Figures should not exceed 69 characters wide to allow for the indent
 of sections.
 
@@ -68,16 +73,21 @@ there is also an anchor. White space, both horizontal and vertical, is
 significant in figures even if you don't use CDATA.
 
 == Subsections and Tables
+
 === A Subsection
+
 By default 3 levels of nesting show in table of contents but that
 can be adjusted with the value of the "tocdepth" processing
 instruction.
 
 === Tables
-... are very similar to figures:
 
-Tables use ttcol to define column headers and widths. Every cell then has a "c" element for its content. [Note: Asciidoc does not support preambles and postambles within tables.]
-         
+pass:[..] are very similar to figures:
+
+//[Note: Asciidoc does not support preambles and postambles within tables.]
+
+Tables use ttcol to define column headers and widths. Every cell then has a "c" element for its content.
+
 [[table_example]]
 .A Very Simple Table
 [cols="2*^"]
@@ -94,7 +104,7 @@ which is a very simple example.
 [[nested_lists]]
 == More about Lists
 Lists with 'hanging labels': the list item is indented the amount of
-the hangIndent: 
+the hangIndent:
 
 [hang-indent=8]
 short:: With a label shorter than the hangIndent.
@@ -105,8 +115,8 @@ vspace_trick:: {blank} +
 Forces the new item to start on a new line.
 
 Simulating more than one paragraph in a list item using
-&lt;vspace&gt;: 
-     
+&lt;vspace&gt;:
+
 [loweralpha]
 . First, a short item.
 
@@ -116,19 +126,19 @@ And something that looks like a separate pararaph..
 
 NOTE: In Asciidoc, it *is* a separate paragraph.
 
-Simple indented paragraph using the "empty" style: 
+Simple indented paragraph using the "empty" style:
 
 [hang-indent=8,empty]
 * The quick, brown fox jumped over the lazy dog and lived to fool
          many another hunter in the great wood in the west.
-         
-         
+
+
 === Numbering Lists across Lists and Sections
 Numbering items continuously although they are in separate
 &lt;list&gt; elements, maybe in separate sections using the "format"
 style and a "counter" variable.
 
-First list: 
+First list:
 
 [hang-indent=4,counter=reqs,format=R%d]
 . #1
@@ -140,7 +150,7 @@ First list:
 Specify the indent explicitly so that all the items line up
 nicely.
 
-Second list: 
+Second list:
 [hang-indent=4,counter=reqs,format=R%d]
 . #4
 
@@ -151,7 +161,7 @@ Second list:
 === Where the List Numbering Continues
 List continues here.
 
-Third list: 
+Third list:
 [hang-indent=4,counter=reqs,format=R%d]
 . #7
 
@@ -228,173 +238,89 @@ See <<RFC3552,RFC 3552>> for a guide.
 == Normative References
 ++++
 
-<reference anchor='RFC2119'>
-
+<reference  anchor='RFC2119' target='https://www.rfc-editor.org/info/rfc2119'>
 <front>
-<title abbrev='RFC Key Words'>Key words for use in RFCs to Indicate Requirement Levels</title>
-<author initials='S.' surname='Bradner' fullname='Scott Bradner'>
-<organization>Harvard University</organization>
-<address>
-<postal>
-<street>1350 Mass. Ave.</street>
-<street>Cambridge</street>
-<street>MA 02138</street></postal>
-<phone>- +1 617 495 3864</phone>
-<email>sob@harvard.edu</email></address></author>
+<title>Key words for use in RFCs to Indicate Requirement Levels</title>
+<author initials='S.' surname='Bradner' fullname='S. Bradner'><organization /></author>
 <date year='1997' month='March' />
-<area>General</area>
-<keyword>keyword</keyword>
-<abstract>
-<t>
-   In many standards track documents several words are used to signify
-   the requirements in the specification.  These words are often
-   capitalized.  This document defines these words as they should be
-   interpreted in IETF documents.  Authors who follow these guidelines
-   should incorporate this phrase near the beginning of their document:
-
-<list>
-<t>
-      The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL
-      NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and
-      "OPTIONAL" in this document are to be interpreted as described in
-      RFC 2119.
-</t></list></t>
-<t>
-   Note that the force of these words is modified by the requirement
-   level of the document in which they are used.
-</t></abstract></front>
-
-<seriesInfo name='BCP' value='14' />
-<seriesInfo name='RFC' value='2119' />
-<format type='TXT' octets='4723' target='ftp://ftp.isi.edu/in-notes/rfc2119.txt' />
-<format type='HTML' octets='17491' target='http://xml.resource.org/public/rfc/html/rfc2119.html' />
-<format type='XML' octets='5777' target='http://xml.resource.org/public/rfc/xml/rfc2119.xml' />
+<abstract><t>In many standards track documents several words are used to signify the requirements in the specification.  These words are often capitalized. This document defines these words as they should be interpreted in IETF documents.  This document specifies an Internet Best Current Practices for the Internet Community, and requests discussion and suggestions for improvements.</t></abstract>
+</front>
+<seriesInfo name='BCP' value='14'/>
+<seriesInfo name='RFC' value='2119'/>
+<seriesInfo name='DOI' value='10.17487/RFC2119'/>
 </reference>
 
-     <reference anchor="min_ref">
-       <!-- the following is the minimum to make xml2rfc happy -->
+<reference anchor="min_ref">
+ <!-- the following is the minimum to make xml2rfc happy -->
 
-       <front>
-         <title>Minimal Reference</title>
+ <front>
+   <title>Minimal Reference</title>
 
-         <author initials="authInitials" surname="authSurName">
-           <organization></organization>
-         </author>
+   <author initials="authInitials" surname="authSurName">
+     <organization></organization>
+   </author>
 
-         <date year="2006" />
-       </front>
-     </reference>
+   <date year="2006" />
+ </front>
+</reference>
 ++++
 
 [bibliography]
 == Informative References
 ++++
-     <!-- Here we use entities that we defined at the beginning. -->
+<!-- Here we use entities that we defined at the beginning. -->
 
-
-<reference anchor='RFC2629'>
-
+<reference  anchor='RFC2629' target='https://www.rfc-editor.org/info/rfc2629'>
 <front>
 <title>Writing I-Ds and RFCs using XML</title>
-<author initials='M.T.' surname='Rose' fullname='Marshall T. Rose'>
-<organization>Invisible Worlds, Inc.</organization>
-<address>
-<postal>
-<street>660 York Street</street>
-<city>San Francisco</city>
-<region>CA</region>
-<code>94110</code>
-<country>US</country></postal>
-<phone>+1 415 695 3975</phone>
-<email>mrose@not.invisible.net</email>
-<uri>http://invisible.net/</uri></address></author>
+<author initials='M.' surname='Rose' fullname='M. Rose'><organization /></author>
 <date year='1999' month='June' />
-<area>General</area>
-<keyword>RFC</keyword>
-<keyword>Request for Comments</keyword>
-<keyword>I-D</keyword>
-<keyword>Internet-Draft</keyword>
-<keyword>XML</keyword>
-<keyword>Extensible Markup Language</keyword>
-<abstract>
-<t>This memo presents a technique for using XML
-(Extensible Markup Language)
-as a source format for documents in the Internet-Drafts (I-Ds) and
-Request for Comments (RFC) series.</t></abstract></front>
-
-<seriesInfo name='RFC' value='2629' />
-<format type='TXT' octets='48677' target='http://www.rfc-editor.org/rfc/rfc2629.txt' />
-<format type='HTML' octets='71741' target='http://xml.resource.org/public/rfc/html/rfc2629.html' />
-<format type='XML' octets='53481' target='http://xml.resource.org/public/rfc/xml/rfc2629.xml' />
-</reference>
-
-
-<reference anchor="RFC3552" target="https://www.rfc-editor.org/info/rfc3552">
-<front>
-<title>
-Guidelines for Writing RFC Text on Security Considerations
-</title>
-<author initials="E." surname="Rescorla" fullname="E. Rescorla">
-<organization/>
-</author>
-<author initials="B." surname="Korver" fullname="B. Korver">
-<organization/>
-</author>
-<date year="2003" month="July"/>
-<abstract>
-<t>
-All RFCs are required to have a Security Considerations section. Historically, such sections have been relatively weak. This document provides guidelines to RFC authors on how to write a good Security Considerations section. This document specifies an Internet Best Current Practices for the Internet Community, and requests discussion and suggestions for improvements.
-</t>
-</abstract>
+<abstract><t>This memo presents a technique for using XML (Extensible Markup Language) as a source format for documents in the Internet-Drafts (I-Ds) and Request for Comments (RFC) series.  This memo provides information for the Internet community.</t></abstract>
 </front>
-<seriesInfo name="BCP" value="72"/>
-<seriesInfo name="RFC" value="3552"/>
-<seriesInfo name="DOI" value="10.17487/RFC3552"/>
+<seriesInfo name='RFC' value='2629'/>
+<seriesInfo name='DOI' value='10.17487/RFC2629'/>
 </reference>
 
-
-<reference anchor="RFC5226" target="https://www.rfc-editor.org/info/rfc5226">
+<reference  anchor='RFC3552' target='https://www.rfc-editor.org/info/rfc3552'>
 <front>
-<title>
-Guidelines for Writing an IANA Considerations Section in RFCs
-</title>
-<author initials="T." surname="Narten" fullname="T. Narten">
-<organization/>
-</author>
-<author initials="H." surname="Alvestrand" fullname="H. Alvestrand">
-<organization/>
-</author>
-<date year="2008" month="May"/>
-<abstract>
-<t>
-Many protocols make use of identifiers consisting of constants and other well-known values. Even after a protocol has been defined and deployment has begun, new values may need to be assigned (e.g., for a new option type in DHCP, or a new encryption or authentication transform for IPsec). To ensure that such quantities have consistent values and interpretations across all implementations, their assignment must be administered by a central authority. For IETF protocols, that role is provided by the Internet Assigned Numbers Authority (IANA).
-</t>
-<t>
-In order for IANA to manage a given namespace prudently, it needs guidelines describing the conditions under which new values can be assigned or when modifications to existing values can be made. If IANA is expected to play a role in the management of a namespace, IANA must be given clear and concise instructions describing that role. This document discusses issues that should be considered in formulating a policy for assigning values to a namespace and provides guidelines for authors on the specific text that must be included in documents that place demands on IANA.
-</t>
-<t>
-This document obsoletes RFC 2434. This document specifies an Internet Best Current Practices for the Internet Community, and requests discussion and suggestions for improvements.
-</t>
-</abstract>
+<title>Guidelines for Writing RFC Text on Security Considerations</title>
+<author initials='E.' surname='Rescorla' fullname='E. Rescorla'><organization /></author>
+<author initials='B.' surname='Korver' fullname='B. Korver'><organization /></author>
+<date year='2003' month='July' />
+<abstract><t>All RFCs are required to have a Security Considerations section. Historically, such sections have been relatively weak.  This document provides guidelines to RFC authors on how to write a good Security Considerations section.   This document specifies an Internet Best Current Practices for the Internet Community, and requests discussion and suggestions for improvements.</t></abstract>
 </front>
-<seriesInfo name="RFC" value="5226"/>
-<seriesInfo name="DOI" value="10.17487/RFC5226"/>
+<seriesInfo name='BCP' value='72'/>
+<seriesInfo name='RFC' value='3552'/>
+<seriesInfo name='DOI' value='10.17487/RFC3552'/>
 </reference>
 
-     <!-- A reference written by by an organization not a person. -->
+<reference  anchor='RFC5226' target='https://www.rfc-editor.org/info/rfc5226'>
+<front>
+<title>Guidelines for Writing an IANA Considerations Section in RFCs</title>
+<author initials='T.' surname='Narten' fullname='T. Narten'><organization /></author>
+<author initials='H.' surname='Alvestrand' fullname='H. Alvestrand'><organization /></author>
+<date year='2008' month='May' />
+<abstract><t>Many protocols make use of identifiers consisting of constants and other well-known values.  Even after a protocol has been defined and deployment has begun, new values may need to be assigned (e.g., for a new option type in DHCP, or a new encryption or authentication transform for IPsec).  To ensure that such quantities have consistent values and interpretations across all implementations, their assignment must be administered by a central authority.  For IETF protocols, that role is provided by the Internet Assigned Numbers Authority (IANA).</t><t>In order for IANA to manage a given namespace prudently, it needs guidelines describing the conditions under which new values can be assigned or when modifications to existing values can be made.  If IANA is expected to play a role in the management of a namespace, IANA must be given clear and concise instructions describing that role.  This document discusses issues that should be considered in formulating a policy for assigning values to a namespace and provides guidelines for authors on the specific text that must be included in documents that place demands on IANA.</t><t>This document obsoletes RFC 2434.  This document specifies an Internet Best  Current Practices for the Internet Community, and requests discussion and  suggestions for improvements.</t></abstract>
+</front>
+<seriesInfo name='RFC' value='5226'/>
+<seriesInfo name='DOI' value='10.17487/RFC5226'/>
+</reference>
 
-     <reference anchor="DOMINATION"
-                target="http://www.example.com/dominator.html">
-       <front>
-         <title>Ultimate Plan for Taking Over the World</title>
 
-         <author>
-           <organization>Mad Dominators, Inc.</organization>
-         </author>
+<!-- A reference written by by an organization not a person. -->
 
-         <date year="1984" />
-       </front>
-     </reference>
+<reference anchor="DOMINATION"
+           target="http://www.example.com/dominator.html">
+  <front>
+    <title>Ultimate Plan for Taking Over the World</title>
+
+    <author>
+      <organization>Mad Dominators, Inc.</organization>
+    </author>
+
+    <date year="1984" />
+  </front>
+</reference>
 ++++
 
 [[app-additional]]
@@ -402,7 +328,7 @@ This document obsoletes RFC 2434. This document specifies an Internet Best Curre
 == Additional Stuff
 This becomes an Appendix.
 
-
+////
    <!-- Change Log
 
 v00 2006-03-15  EBD   Initial version
@@ -417,9 +343,10 @@ v03 2007-03-09  EBD   Added comments on null IANA sections and fixed heading cap
                      Fixed up the date specification comments to reflect current truth.
 v04 2007-03-09 AH     Major changes: shortened discussion of PIs,
                      added discussion of rfc include.
-v05 2007-03-10 EBD    Added preamble to C program example to tell about ABNF and alternative 
+v05 2007-03-10 EBD    Added preamble to C program example to tell about ABNF and alternative
                      images. Removed meta-characters from comments (causes problems).
 
 v06 2010-04-01 TT     Changed ipr attribute values to latest ones. Changed date to
-                     year only, to be consistent with the comments. Updated the 
+                     year only, to be consistent with the comments. Updated the
                      IANA guidelines reference from the I-D to the finished RFC.  -->
+////

--- a/spec/examples/davies-template-bare-06.adoc
+++ b/spec/examples/davies-template-bare-06.adoc
@@ -67,7 +67,7 @@ Cross-references allowed in pre- and postamble. <<min_ref>>.
 ====
 
 The CDATA means you don't need to escape meta-characters (especially
-&lt;&nbsp;(&amp;lt;) and &amp;&nbsp;(&amp;amp;)) but is not essential.
+< (\&lt;) and & (\&amp;)) but is not essential.
 Figures may also have a title attribute but it won't be displayed unless
 there is also an anchor. White space, both horizontal and vertical, is
 significant in figures even if you don't use CDATA.
@@ -115,7 +115,7 @@ vspace_trick:: {blank} +
 Forces the new item to start on a new line.
 
 Simulating more than one paragraph in a list item using
-&lt;vspace&gt;:
+<vspace>:
 
 [loweralpha]
 . First, a short item.
@@ -135,7 +135,7 @@ Simple indented paragraph using the "empty" style:
 
 === Numbering Lists across Lists and Sections
 Numbering items continuously although they are in separate
-&lt;list&gt; elements, maybe in separate sections using the "format"
+<list> elements, maybe in separate sections using the "format"
 style and a "counter" variable.
 
 First list:
@@ -176,8 +176,11 @@ The end of the list.
 [[codeExample]]
 == Example of Code or MIB Module To Be Extracted
 
+// NOTE: in asciidoctor-rfc output we're missing an empty line before
+// the code block and after it. Can't figure out a way to create that...
+
 ====
-The &lt;artwork&gt; element has a number of extra attributes
+The <artwork> element has a number of extra attributes
 that can be used to substitute a more aesthetically pleasing rendition
 into HTML output while continuing to use the ASCII art version in the
 text and nroff outputs (see the xml2rfc README for details). It also

--- a/spec/examples/davies-template-bare-06.xml.orig
+++ b/spec/examples/davies-template-bare-06.xml.orig
@@ -83,7 +83,7 @@
      </address>
    </author>
 
-   <date year="2010" />
+   <date year="2010" month="April" day="1"/>
 
    <!-- If the month and year are both specified and are the current ones, xml2rfc will fill 
         in the current day for you. If only the current year is specified, xml2rfc will fill 


### PR DESCRIPTION
I was going to propose our workflow to the RFC editor mailing list, and wanted to give them a good example such as the `davies-template-bare-06` file.

However `xml2rfc` didn't work with the generated file because it lacked XML processing instructions and some formatting was different.

Therefore I made the fixes here to minimize the resulting diff.

Currently the remaining diff (below) are due these issues:
* Table preamble / postamble is not supported in asciidoctor.
* Table column size -- it should support the minimal column size provided in the XML.
* The "empty" list format is not supported in our gem yet (is it supported in asciidoctor?)
* Some whitespacing issues?
* DTD is missing.

We should fix all these in separate issue tickets and include this file in actual spec to test against XML/TXT outputs.

I'm using this command to generate this diff.

```sh
bundle exec bin/asciidoctor-rfc2 spec/examples/davies-template-bare-06.adoc --trace; \
  xml2rfc spec/examples/davies-template-bare-06.xml -o new.txt; \
  xml2rfc spec/examples/davies-template-bare-06.xml.orig -o old.txt; \
  diff old.txt new.txt 
```

Diff:
```
Parsing file spec/examples/davies-template-bare-06.xml
WARNING: No DTD given, defaulting to /usr/local/lib/python3.6/site-packages/xml2rfc/templates/rfc2629.dtd
Created file new.txt
Parsing file spec/examples/davies-template-bare-06.xml.orig
Created file old.txt
81c81
<    Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .   8
---
>    Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .   7
149,150c149,150
<      Tables use ttcol to define column headers and widths.  Every cell
<                   then has a "c" element for its content.
---
>    Tables use ttcol to define column headers and widths.  Every cell
>    then has a "c" element for its content.
152,160c152,160
<                           +----------+----------+
<                           | ttcol #1 | ttcol #2 |
<                           +----------+----------+
<                           |   c #1   |   c #2   |
<                           |   c #3   |   c #4   |
<                           |   c #5   |   c #6   |
<                           +----------+----------+
< 
<                       which is a very simple example.
---
>    +---------------------------------+---------------------------------+
>    |             ttcol #1            |             ttcol #2            |
>    +---------------------------------+---------------------------------+
>    |               c #1              |               c #2              |
>    +---------------------------------+---------------------------------+
>    |               c #3              |               c #4              |
>    +---------------------------------+---------------------------------+
>    |               c #5              |               c #6              |
>    +---------------------------------+---------------------------------+
164c164
< 
---
>    which is a very simple example.
190d189
< 
195c194
<       The quick, brown fox jumped over the lazy dog and lived to fool
---
>    o  The quick, brown fox jumped over the lazy dog and lived to fool
223a223
> 
298d297
< 
318d316
< 
332a331,332
>    [RFC5226] for a guide).  If the draft does not require IANA to do
>    anything, the section contains an explicit statement that this is the
341,342d340
<    [RFC5226] for a guide).  If the draft does not require IANA to do
<    anything, the section contains an explicit statement that this is the
385a384,385
> Author's Address
> 
397,398d396
< Author's Address
< 
447a446,447
> 
> 
```
