### PR TITLE
docs: Add docs/ subtree for use with Ribose Open

### DIFF
--- a/docs/_navigation.md
+++ b/docs/_navigation.md
@@ -1,0 +1,5 @@
+---
+- Introduction
+  - overview
+  - installation
+---

--- a/docs/_navigation.md
+++ b/docs/_navigation.md
@@ -1,6 +1,0 @@
----
-sections:
-  - Introduction
-    - overview
-    - installation
----

--- a/docs/_navigation.md
+++ b/docs/_navigation.md
@@ -1,5 +1,6 @@
 ---
-- Introduction
-  - overview
-  - installation
+sections:
+  - Introduction
+    - overview
+    - installation
 ---

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,19 @@
+# Installation
+
+Add this line to your application’s Gemfile:
+
+```
+gem "asciidoctor-rfc"
+```
+
+And then execute:
+
+```
+$ bundle
+```
+
+Or install it yourself as:
+
+```
+$ gem install asciidoctor-rfc
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,4 +1,6 @@
-# Installation
+---
+title: Installation
+---
 
 Add this line to your application’s Gemfile:
 

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,0 +1,10 @@
+---
+sections:
+- name: Introduction
+  items:
+    - overview
+    - installation
+- name: Usage
+  items:
+    - basic
+---

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,3 +1,5 @@
-# Overview
+---
+title: Overeview
+---
 
 asciidoctor-rfc lets you write Internet-Drafts and RFCs in AsciiDoc, the “asciidoctor-way”.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,3 @@
+# Overview
+
+asciidoctor-rfc lets you write Internet-Drafts and RFCs in AsciiDoc, the “asciidoctor-way”.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Overeview
+title: Overview
 ---
 
 asciidoctor-rfc lets you write Internet-Drafts and RFCs in AsciiDoc, the “asciidoctor-way”.


### PR DESCRIPTION
This is part of RO integration pilot. At this time please don’t mind the contents of docs/ and maintain only the README.